### PR TITLE
CT-78-add-contract-tester-tests

### DIFF
--- a/ContractTester.Tests/ContractTester.Tests.csproj
+++ b/ContractTester.Tests/ContractTester.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Messages\Sales.Messages.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ContractTester.Tests/ContractTester.Tests.csproj
+++ b/ContractTester.Tests/ContractTester.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ClientUI\ClientUI.csproj" />
     <ProjectReference Include="..\Messages\Sales.Messages.csproj" />
+    <ProjectReference Include="..\Sales.Events\Sales.Events.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ContractTester.Tests/ContractTester.Tests.csproj
+++ b/ContractTester.Tests/ContractTester.Tests.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.0" />
@@ -14,7 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ClientUI\ClientUI.csproj" />
     <ProjectReference Include="..\Messages\Sales.Messages.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ContractTester.Tests/ContractTesterSettings.cs
+++ b/ContractTester.Tests/ContractTesterSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace ContractTester.Tests
+{
+    public class ContractTesterSettings
+    {
+        public string TestMessageApiUrl { get; set; }
+    }
+}

--- a/ContractTester.Tests/ContractTesterSettings.cs
+++ b/ContractTester.Tests/ContractTesterSettings.cs
@@ -3,5 +3,6 @@
     public class ContractTesterSettings
     {
         public string TestMessageApiUrl { get; set; }
+        public string ValidPlaceOrderContractId { get; set; }
     }
 }

--- a/ContractTester.Tests/ContractTesterSettings.cs
+++ b/ContractTester.Tests/ContractTesterSettings.cs
@@ -4,5 +4,6 @@
     {
         public string TestMessageApiUrl { get; set; }
         public string ValidPlaceOrderContractId { get; set; }
+        public string ValidOrderCompletedContractId { get; set; }
     }
 }

--- a/ContractTester.Tests/IContractTesterTemplate.cs
+++ b/ContractTester.Tests/IContractTesterTemplate.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ContractTester.Tests
+{
+    public interface IContractTesterTemplate
+    {
+        Guid ContractId { get; set; }
+        IMessageDetails Message { get; set; }
+    }
+
+    public interface IMessageDetails
+    {
+        Guid? Id { get; set; }
+        DateTime Timestamp { get; set; }
+    }
+}

--- a/ContractTester.Tests/SalesBC/OrderCompletedTests.cs
+++ b/ContractTester.Tests/SalesBC/OrderCompletedTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Sales.Events;
+using Shouldly;
+using Xunit;
+
+namespace ContractTester.Tests.SalesBC
+{
+    using static Testing;
+
+    public class OrderCompletedTests
+    {
+        public static HttpClient Client = new HttpClient();
+        private readonly ContractTesterSettings _contractTesterSettings;
+
+        public OrderCompletedTests()
+        {
+            _contractTesterSettings = GetContractTesterApplicationConfigurationSettings();
+        }
+
+        [Fact]
+        public async Task ShouldReturnSuccessForValidContract()
+        {
+            var orderCompleted = new OrderCompleted {OrderId = "order 111"};
+
+            var placeOrderMessage = new OrderCompletedContract
+            {
+                ContractId = Guid.Parse(_contractTesterSettings.ValidOrderCompletedContractId),
+                Message = new OrderCompleteMessageDetails
+                {
+                    Id = Guid.NewGuid(),
+                    OrderId = orderCompleted.OrderId,
+                    Timestamp = DateTime.Now
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task ShouldReturnBadRequestForInvalidMessageIdForContract()
+        {
+            var orderCompleted = new OrderCompleted { OrderId = "order 222" };
+
+            var placeOrderMessage = new OrderCompletedContract
+            {
+                ContractId = Guid.Parse(_contractTesterSettings.ValidOrderCompletedContractId),
+                Message = new OrderCompleteMessageDetails
+                {
+                    Id = null,
+                    OrderId = orderCompleted.OrderId,
+                    Timestamp = DateTime.Now
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            responseString.ShouldContain("Message does not match contract");
+        }
+
+        [Fact]
+        public async Task ShouldReturnBadRequestForInvalidContractIdForContract()
+        {
+            var invalidGuid = Guid.NewGuid();
+            var orderCompleted = new OrderCompleted { OrderId = "order 333" };
+
+            var placeOrderMessage = new OrderCompletedContract
+            {
+                ContractId = invalidGuid,
+                Message = new OrderCompleteMessageDetails
+                {
+                    Id = Guid.NewGuid(),
+                    OrderId = orderCompleted.OrderId,
+                    Timestamp = DateTime.Now
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            responseString.ShouldContain("Unable to test message; confirm that your request message is valid JSON.");
+        }
+
+        [Fact]
+        public async Task ShouldReturnBadRequestForInvalidPropertyForContract()
+        {
+            var placeOrderMessage = new OrderCompletedContract
+            {
+                ContractId = Guid.Parse(_contractTesterSettings.ValidOrderCompletedContractId),
+                Message = new OrderCompleteMessageDetailsWithAdditionalField
+                {
+                    Id = Guid.NewGuid(),
+                    Timestamp = DateTime.Now,
+                    InvalidField = "this should error out"
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            responseString.ShouldContain("Message property \\\"InvalidField\\\" is not part of the contract.");
+        }
+    }
+
+    public class OrderCompletedContract : IContractTesterTemplate
+    {
+        public Guid ContractId { get; set; }
+        public IMessageDetails Message { get; set; }
+    }
+
+    public class OrderCompleteMessageDetails : IMessageDetails
+    {
+        public string OrderId { get; set; }
+        public Guid? Id { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
+    public class OrderCompleteMessageDetailsWithAdditionalField : IMessageDetails
+    {
+        public string InvalidField { get; set; }
+        public Guid? Id { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/ContractTester.Tests/SalesBC/PlaceOrderTests.cs
+++ b/ContractTester.Tests/SalesBC/PlaceOrderTests.cs
@@ -35,7 +35,7 @@ namespace ContractTester.Tests.SalesBC
             var placeOrderMessage = new PlaceOrderContract
             {
                 ContractId = Guid.Parse(_contractTesterSettings.ValidPlaceOrderContractId),
-                Message = new MessageDetails
+                Message = new PlaceOrderMessageDetails
                 {
                     Id = Guid.NewGuid(),
                     ItemName = placeOrder.ItemName,
@@ -64,7 +64,7 @@ namespace ContractTester.Tests.SalesBC
             var placeOrderMessage = new PlaceOrderContract
             {
                 ContractId = Guid.Parse(_contractTesterSettings.ValidPlaceOrderContractId),
-                Message = new MessageDetails
+                Message = new PlaceOrderMessageDetails
                 {
                     Id = null,
                     ItemName = placeOrder.ItemName,
@@ -97,7 +97,7 @@ namespace ContractTester.Tests.SalesBC
             var placeOrderMessage = new PlaceOrderContract
             {
                 ContractId = invalidGuid,
-                Message = new MessageDetails
+                Message = new PlaceOrderMessageDetails
                 {
                     Id = Guid.NewGuid(),
                     ItemName = placeOrder.ItemName,
@@ -131,9 +131,6 @@ namespace ContractTester.Tests.SalesBC
                 Message = new MessageDetailsWithAdditionalField
                 {
                     Id = Guid.NewGuid(),
-                    ItemName = placeOrder.ItemName,
-                    OrderDate = placeOrder.OrderDate,
-                    OrderId = placeOrder.OrderId,
                     Timestamp = DateTime.Now,
                     InvalidField = "this should error out"
                 }
@@ -148,13 +145,13 @@ namespace ContractTester.Tests.SalesBC
         }
     }
 
-    public class PlaceOrderContract
+    public class PlaceOrderContract : IContractTesterTemplate
     {
         public Guid ContractId { get; set; }
-        public MessageDetails Message { get; set; }
+        public IMessageDetails Message { get; set; }
     }
 
-    public class MessageDetails
+    public class PlaceOrderMessageDetails : IMessageDetails
     {
         public Guid? Id { get; set; }
         public string ItemName { get; set; }
@@ -163,8 +160,10 @@ namespace ContractTester.Tests.SalesBC
         public DateTime Timestamp { get; set; }
     }
 
-    public class MessageDetailsWithAdditionalField : MessageDetails
+    public class MessageDetailsWithAdditionalField : IMessageDetails
     {
         public string InvalidField { get; set; }
+        public Guid? Id { get; set; }
+        public DateTime Timestamp { get; set; }
     }
 }

--- a/ContractTester.Tests/SalesBC/PlaceOrderTests.cs
+++ b/ContractTester.Tests/SalesBC/PlaceOrderTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Sales.Messages;
+using Shouldly;
+using Xunit;
+
+namespace ContractTester.Tests.SalesBC
+{
+    public class PlaceOrderTests
+    {
+        public static HttpClient Client = new HttpClient();
+        public const string ValidPlaceOrderContractId = "DFBF39EA-62A1-4C51-78F7-08D70F8D1BDD";
+
+        [Fact]
+        public async Task ShouldReturnSuccessForValidContract()
+        {
+            var placeOrder = new PlaceOrder
+            {
+                OrderId = "123abc",
+                ItemName = "Frying Pan",
+                OrderDate = DateTime.Now
+            };
+
+            var placeOrderMessage = new PlaceOrderContract
+            {
+                ContractId = Guid.Parse(ValidPlaceOrderContractId),
+                Message = new PlaceOrderMessage
+                {
+                    Id = Guid.NewGuid(),
+                    ItemName = placeOrder.ItemName,
+                    OrderDate = placeOrder.OrderDate,
+                    OrderId = placeOrder.OrderId,
+                    Timestamp = DateTime.Now
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+
+            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task ShouldReturnBadRequestForInvalidMessageIdForContract()
+        {
+            var placeOrder = new PlaceOrder
+            {
+                OrderId = "456def",
+                ItemName = "Griddle",
+                OrderDate = DateTime.Now
+            };
+
+            var placeOrderMessage = new PlaceOrderContract
+            {
+                ContractId = Guid.Parse(ValidPlaceOrderContractId),
+                Message = new PlaceOrderMessage
+                {
+                    Id = null,
+                    ItemName = placeOrder.ItemName,
+                    OrderDate = placeOrder.OrderDate,
+                    OrderId = placeOrder.OrderId,
+                    Timestamp = DateTime.Now
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+
+            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            var responseString = await response.Content.ReadAsStringAsync();
+            responseString.ShouldContain("Message does not match contract");
+        }
+
+        [Fact]
+        public async Task ShouldReturnBadRequestForInvalidContractIdForContract()
+        {
+            var placeOrder = new PlaceOrder
+            {
+                OrderId = "678ghi",
+                ItemName = "Nu wave oven",
+                OrderDate = DateTime.Now
+            };
+
+            var invalidGuid = Guid.NewGuid();
+
+            var placeOrderMessage = new PlaceOrderContract
+            {
+                ContractId = invalidGuid,
+                Message = new PlaceOrderMessage
+                {
+                    Id = null,
+                    ItemName = placeOrder.ItemName,
+                    OrderDate = placeOrder.OrderDate,
+                    OrderId = placeOrder.OrderId,
+                    Timestamp = DateTime.Now
+                }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
+
+            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            var responseString = await response.Content.ReadAsStringAsync();
+            responseString.ShouldContain("Unable to test message; confirm that your request message is valid JSON.");
+        }
+    }
+
+    public class PlaceOrderContract
+    {
+        public Guid ContractId { get; set; }
+        public PlaceOrderMessage Message { get; set; }
+    }
+
+    public class PlaceOrderMessage
+    {
+        public Guid? Id { get; set; }
+        public string ItemName { get; set; }
+        public DateTime OrderDate { get; set; }
+        public string OrderId { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/ContractTester.Tests/SalesBC/PlaceOrderTests.cs
+++ b/ContractTester.Tests/SalesBC/PlaceOrderTests.cs
@@ -10,10 +10,17 @@ using Xunit;
 
 namespace ContractTester.Tests.SalesBC
 {
+    using static Testing;
+
     public class PlaceOrderTests
     {
         public static HttpClient Client = new HttpClient();
-        public const string ValidPlaceOrderContractId = "DFBF39EA-62A1-4C51-78F7-08D70F8D1BDD";
+        private readonly ContractTesterSettings _contractTesterSettings;
+
+        public PlaceOrderTests()
+        {
+            _contractTesterSettings = GetContractTesterApplicationConfigurationSettings();
+        }
 
         [Fact]
         public async Task ShouldReturnSuccessForValidContract()
@@ -27,7 +34,7 @@ namespace ContractTester.Tests.SalesBC
 
             var placeOrderMessage = new PlaceOrderContract
             {
-                ContractId = Guid.Parse(ValidPlaceOrderContractId),
+                ContractId = Guid.Parse(_contractTesterSettings.ValidPlaceOrderContractId),
                 Message = new MessageDetails
                 {
                     Id = Guid.NewGuid(),
@@ -39,8 +46,7 @@ namespace ContractTester.Tests.SalesBC
             };
 
             var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
-
-            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
 
             response.EnsureSuccessStatusCode();
         }
@@ -57,7 +63,7 @@ namespace ContractTester.Tests.SalesBC
 
             var placeOrderMessage = new PlaceOrderContract
             {
-                ContractId = Guid.Parse(ValidPlaceOrderContractId),
+                ContractId = Guid.Parse(_contractTesterSettings.ValidPlaceOrderContractId),
                 Message = new MessageDetails
                 {
                     Id = null,
@@ -69,10 +75,9 @@ namespace ContractTester.Tests.SalesBC
             };
 
             var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
-
-            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
-
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
             response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
             var responseString = await response.Content.ReadAsStringAsync();
             responseString.ShouldContain("Message does not match contract");
         }
@@ -103,10 +108,9 @@ namespace ContractTester.Tests.SalesBC
             };
 
             var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
-
-            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
-
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
             response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
             var responseString = await response.Content.ReadAsStringAsync();
             responseString.ShouldContain("Unable to test message; confirm that your request message is valid JSON.");
         }
@@ -123,8 +127,8 @@ namespace ContractTester.Tests.SalesBC
 
             var placeOrderMessage = new PlaceOrderContract
             {
-                ContractId = Guid.Parse(ValidPlaceOrderContractId),
-                Message = new InvalidMessageDetails
+                ContractId = Guid.Parse(_contractTesterSettings.ValidPlaceOrderContractId),
+                Message = new MessageDetailsWithAdditionalField
                 {
                     Id = Guid.NewGuid(),
                     ItemName = placeOrder.ItemName,
@@ -136,10 +140,9 @@ namespace ContractTester.Tests.SalesBC
             };
 
             var stringContent = new StringContent(JsonConvert.SerializeObject(placeOrderMessage), Encoding.UTF8, "application/json");
-
-            var response = await Client.PostAsync("https://localhost:5001/api/TestMessage", stringContent);
-
+            var response = await Client.PostAsync(_contractTesterSettings.TestMessageApiUrl, stringContent);
             response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
             var responseString = await response.Content.ReadAsStringAsync();
             responseString.ShouldContain("Message property \\\"InvalidField\\\" is not part of the contract.");
         }
@@ -160,7 +163,7 @@ namespace ContractTester.Tests.SalesBC
         public DateTime Timestamp { get; set; }
     }
 
-    public class InvalidMessageDetails : MessageDetails
+    public class MessageDetailsWithAdditionalField : MessageDetails
     {
         public string InvalidField { get; set; }
     }

--- a/ContractTester.Tests/Testing.cs
+++ b/ContractTester.Tests/Testing.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using ClientUI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ContractTester.Tests
+{
+    public static class Testing
+    {
+        private static readonly IServiceScopeFactory ScopeFactory;
+        public static IConfigurationRoot Configuration { get; }
+
+        static Testing()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+
+            Configuration = new ConfigurationBuilder()
+                .SetBasePath(currentDirectory)
+                .AddJsonFile("appsettings.json", true, true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var startup = new Startup(Configuration);
+            var services = new ServiceCollection();
+
+            startup.ConfigureServices(services);
+
+            var rootContainer = services.BuildServiceProvider();
+            ScopeFactory = rootContainer.GetService<IServiceScopeFactory>();
+        }
+
+        public static ContractTesterSettings GetContractTesterApplicationConfigurationSettings()
+        {
+            var contractTesterSettings = new ContractTesterSettings();
+            var appSettings = Configuration.GetSection(nameof(ContractTesterSettings));
+            appSettings.Bind(contractTesterSettings);
+
+            return contractTesterSettings;
+        }
+    }
+}

--- a/ContractTester.Tests/appsettings.json
+++ b/ContractTester.Tests/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ContractTesterSettings": {
     "TestMessageApiUrl": "https://localhost:5001/api/TestMessage",
-    "ValidPlaceOrderContractId": "DFBF39EA-62A1-4C51-78F7-08D70F8D1BDD"
+    "ValidPlaceOrderContractId": "DFBF39EA-62A1-4C51-78F7-08D70F8D1BDD",
+    "ValidOrderCompletedContractId": "E238A605-69CE-4A71-B4C0-08D710670225"
   }
 }

--- a/ContractTester.Tests/appsettings.json
+++ b/ContractTester.Tests/appsettings.json
@@ -1,5 +1,6 @@
 {
   "ContractTesterSettings": {
-    "TestMessageApiUrl": "https://localhost:5001/api/TestMessage"
+    "TestMessageApiUrl": "https://localhost:5001/api/TestMessage",
+    "ValidPlaceOrderContractId": "DFBF39EA-62A1-4C51-78F7-08D70F8D1BDD"
   }
 }

--- a/ContractTester.Tests/appsettings.json
+++ b/ContractTester.Tests/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ContractTesterSettings": {
+    "TestMessageApiUrl": "https://localhost:5001/api/TestMessage"
+  }
+}

--- a/MicroservicesMessagingDemo.sln
+++ b/MicroservicesMessagingDemo.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.705
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientUI", "ClientUI\ClientUI.csproj", "{FE43A59A-76B5-4B6F-87F5-A8EB4A4CF4F2}"
 EndProject
@@ -23,7 +23,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SalesBC", "SalesBC", "{D78C
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ShippingBC", "ShippingBC", "{DF0E1D2B-23EF-476B-8800-CB021053A813}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shipping.Events", "Shipping.Events\Shipping.Events.csproj", "{CCA7F54B-BEFB-49F6-8C43-B2287FA21BAA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shipping.Events", "Shipping.Events\Shipping.Events.csproj", "{CCA7F54B-BEFB-49F6-8C43-B2287FA21BAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContractTester.Tests", "ContractTester.Tests\ContractTester.Tests.csproj", "{B2B0F66B-D25E-4E00-B815-37E77ED6D504}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{CCA7F54B-BEFB-49F6-8C43-B2287FA21BAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCA7F54B-BEFB-49F6-8C43-B2287FA21BAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CCA7F54B-BEFB-49F6-8C43-B2287FA21BAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2B0F66B-D25E-4E00-B815-37E77ED6D504}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2B0F66B-D25E-4E00-B815-37E77ED6D504}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2B0F66B-D25E-4E00-B815-37E77ED6D504}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2B0F66B-D25E-4E00-B815-37E77ED6D504}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add test project to call the ContractTester service api with some test values to ensure if sample messages for a particular contract was valid or not.